### PR TITLE
Updates to voyage to allow for running against the voyage-api-java

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -30,6 +30,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
+        "devjava": "environments/environment.devjava.ts",
         "qa": "environments/environment.qa.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/src/app/authentication/login/login.service.ts
+++ b/src/app/authentication/login/login.service.ts
@@ -14,10 +14,12 @@ export class LoginService {
   login(login: Login): Observable<any> {
     // tslint:disable-next-line:max-line-length
     const body = `username=${login.username}&password=${login.password}&client_id=${environment.OAUTH_CLIENT_ID}&client_secret=${environment.OAUTH_CLIENT_SECRET}&grant_type=password`;
+    const clientCreds = `${environment.OAUTH_CLIENT_ID}:${environment.OAUTH_CLIENT_SECRET}`;
 
     let headers = new HttpHeaders();
-    headers = headers.set('grant_type', 'password');
-    headers = headers.set('content-type', 'application/x-www-form-urlencoded');
+
+    headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
+    headers = headers.set('Authorization', 'Basic ' + btoa(clientCreds));
 
     return this.http.post(`${environment.SERVER_URL}/oauth/token`, body, { headers: headers })
       .map((response: any) => {

--- a/src/app/authentication/security-http-interceptor.ts
+++ b/src/app/authentication/security-http-interceptor.ts
@@ -10,7 +10,8 @@ export class SecurityHttpInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const accessToken = this.authenticationService.getToken();
-    const authRequest = request.clone({setHeaders: {Authorization: `Bearer ${accessToken}`}});
+    // TODO: I think it would be better is authenticationService had an isLoggedIn method to determine if we add the auth token
+    const authRequest = accessToken ? request.clone({setHeaders: {Authorization: `Bearer ${accessToken}`}}) : request;
     return next.handle(authRequest)
       .catch(errorResponse => {
         if (errorResponse.status === 401) {

--- a/src/app/authentication/security-http-interceptor.ts
+++ b/src/app/authentication/security-http-interceptor.ts
@@ -10,7 +10,6 @@ export class SecurityHttpInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const accessToken = this.authenticationService.getToken();
-    // TODO: I think it would be better is authenticationService had an isLoggedIn method to determine if we add the auth token
     const authRequest = accessToken ? request.clone({setHeaders: {Authorization: `Bearer ${accessToken}`}}) : request;
     return next.handle(authRequest)
       .catch(errorResponse => {

--- a/src/environments/environment.devjava.ts
+++ b/src/environments/environment.devjava.ts
@@ -1,0 +1,13 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=devjava` then `environment.devjava.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+export const environment = {
+  production: false,
+  API_URL: 'http://localhost:8080/api/v1',
+  SERVER_URL: 'http://localhost:8080',
+  OAUTH_REDIRECT_URL: 'http://localhost:3000/dashboard',
+  OAUTH_CLIENT_ID: 'client-super',
+  OAUTH_CLIENT_SECRET: 'secret'
+};


### PR DESCRIPTION
Changes
  * Update to login.service.ts
  ** Doesn't need to pass a header for grant_type (already in body of request)
  ** Needs to post to oauth endpoint with Basic Auth using client creds
  * Update to security-http-interceptor.ts
  ** Doesn't apply oauth Auth token if it is null, needed so that login.service.ts could pass Basic Auth header
  * Added angular environment for local dev with voyage-api-java (port 8080)